### PR TITLE
Refactor: unify types, decouple and improve build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,26 @@
 cmake_minimum_required(VERSION 3.27)
+project(TermTetris VERSION 1.0.0)
 
-project(SimpleTetris VERSION 1.0.0)
+# Specify output concise binary name
+set(OUT_BIN_NAME "ttetris")
 
+# Specify the C++ standard
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+# Specify the compilers
+set(CMAKE_C_COMPILER ${CC})
+set(CMAKE_CXX_COMPILER ${CXX})
+
+# Force CMake to use ld.lld, and set linker flags
+set(CMAKE_LINKER "${LD}")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=lld")
+set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -fuse-ld=lld")
+
+# -----------------------------------------------------------------------------
+# Main executable
+# -----------------------------------------------------------------------------
 # define sources and headers
 set(SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp"
@@ -14,13 +33,13 @@ set(HEADERS
 )
 
 # Create the executable
-add_executable(SimpleTetris
+add_executable(${OUT_BIN_NAME}
     ${SOURCES}
     ${HEADERS}
 )
 
 # Set the runtime output directory to be inside the build directory
-set_target_properties(SimpleTetris PROPERTIES
+set_target_properties(${OUT_BIN_NAME} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 
@@ -30,7 +49,7 @@ configure_file(
     "${CMAKE_BINARY_DIR}/include/config.h"
 )
 
-target_include_directories(SimpleTetris PRIVATE
+target_include_directories(${OUT_BIN_NAME} PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
     "${CMAKE_BINARY_DIR}/include" # Ensures config.h can be found
 )

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -5,35 +5,54 @@
         "minor": 27,
         "patch": 0
     },
+    // TODO: consider adding `-mavx2` for AVX2 support
     "configurePresets": [
         {
-            "name": "ux",
-            "displayName": "Unix Makefiles",
-            "description": "Local development using Unix Makefiles",
+            "name": "ux-debug",
+            "displayName": "Unix Makefiles Debug",
+            "description": "Debug build using Unix Makefiles",
             "hidden": false,
             "binaryDir": "${sourceDir}/build", // clangd LSP requires no presetName
             "generator": "Unix Makefiles",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
                 "CMAKE_EXPORT_COMPILE_COMMANDS": true,
+                "CMAKE_CXX_STANDARD_REQUIRED": true,
                 "CMAKE_CXX_STANDARD": "20",
-                "CMAKE_CXX_STANDARD_REQUIRED": true
+                "CMAKE_CXX_FLAGS": "-pthread -g -O0 -Wall -Wextra -Wpedantic -DDEBUG -Wno-c11-extensions",
+                "CMAKE_EXE_LINKER_FLAGS": "-g"
             }
-        }
-    ],
-    "buildPresets": [
-        {
-            "name": "ux-debug",
-            "displayName": "Unix Makefiles Debug",
-            "description": "Debug build using Unix Makefiles",
-            "configurePreset": "ux",
-            "configuration": "Debug"
         },
         {
             "name": "ux-release",
             "displayName": "Unix Makefiles Release",
             "description": "Release build using Unix Makefiles",
-            "configurePreset": "ux",
+            "hidden": false,
+            "binaryDir": "${sourceDir}/build", // clangd LSP requires no presetName
+            "generator": "Unix Makefiles",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": true,
+                "CMAKE_CXX_STANDARD_REQUIRED": true,
+                "CMAKE_CXX_STANDARD": "20",
+                "CMAKE_CXX_FLAGS": "-pthread -O3 -DNDEBUG -Wall -Wextra -Wpedantic -Wno-c11-extensions",
+                "CMAKE_EXE_LINKER_FLAGS": "-O3"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "ux-debug-build",
+            "displayName": "Unix Makefiles Debug Build",
+            "description": "Build using the Unix Makefiles Debug configuration",
+            "configurePreset": "ux-debug",
+            "configuration": "Debug"
+        },
+        {
+            "name": "ux-release-build",
+            "displayName": "Unix Makefiles Release Build",
+            "description": "Build using the Unix Makefiles Release configuration",
+            "configurePreset": "ux-release",
             "configuration": "Release"
         }
     ]

--- a/build.sh
+++ b/build.sh
@@ -1,14 +1,56 @@
 #!/bin/sh
 
-BUILD_DIR="build"
+# Function to display usage instructions
+usage() {
+    echo "Usage: $0 [debug|release]"
+    exit 1
+}
+
+# Check if the first argument is supplied
+if [ -z "$1" ]; then
+    usage
+fi
+
+# Determine the build mode based on the argument
+case "$1" in
+    debug)
+        CONFIG_PRESET="ux-debug"
+        BUILD_PRESET="ux-debug-build"
+        ;;
+    release)
+        CONFIG_PRESET="ux-release"
+        BUILD_PRESET="ux-release-build"
+        ;;
+    *)
+        usage
+        ;;
+esac
 
 # Create the build directory if it doesn't exist
+BUILD_DIR="build"
 if [ ! -d "$BUILD_DIR" ]; then
     mkdir "$BUILD_DIR"
 fi
 
-# Build the project
-cmake --preset=ux
-cmake --build --preset=ux-debug
+find_llvm_dir() {
+    for dir in /usr/lib/llvm-*; do
+        if [ -d "$dir" ]; then
+            echo "$dir"
+            return
+        fi
+    done
+    echo ""
+}
 
-echo "Build complete!"
+# Add LLVM to the library path and link flags
+LLVM_DIR=$(find_llvm_dir)
+if [ -n "$LLVM_DIR" ]; then
+    export LD_LIBRARY_PATH="${LLVM_DIR}/lib:$LD_LIBRARY_PATH"
+    export LDFLAGS="-L${LLVM_DIR}/lib"
+fi
+
+# Configure and build the project using the appropriate presets
+cmake --preset=$CONFIG_PRESET
+cmake --build --preset=$BUILD_PRESET
+
+echo "Build complete in $1 mode!"

--- a/include/config.h.in
+++ b/include/config.h.in
@@ -1,5 +1,5 @@
 #pragma once
 
-#define VERSION_MAJOR @SimpleTetris_VERSION_MAJOR@
-#define VERSION_MINOR @SimpleTetris_VERSION_MINOR@
-#define VERSION_PATCH @SimpleTetris_VERSION_PATCH@
+#define VERSION_MAJOR @TermTetris_VERSION_MAJOR@
+#define VERSION_MINOR @TermTetris_VERSION_MINOR@
+#define VERSION_PATCH @TermTetris_VERSION_PATCH@

--- a/include/const.hpp
+++ b/include/const.hpp
@@ -7,11 +7,18 @@
 #pragma once
 
 #include <chrono>
-#include <map>
 #include <stdint.h>
 
 #define HEIGHT 20
 #define WIDTH 10
+#define TOTAL HEIGHT *WIDTH
+#define IDX_NA UINT8_MAX // invalid index
+#define NBRK 4
+
+// Sparse representation of tetrominos on the board as indices
+typedef std::array<uint8_t, NBRK> brick_t;
+// Dense representation of the whole board (IMP: enum class Pixel)
+typedef std::array<uint8_t, TOTAL> field_t;
 
 typedef std::chrono::seconds sec;
 typedef std::chrono::steady_clock steady_clock;

--- a/include/piece.hpp
+++ b/include/piece.hpp
@@ -5,7 +5,6 @@
 // ----------------------------------------------------------------------------
 
 #pragma once
-#include <array>
 
 #include "const.hpp"
 
@@ -32,74 +31,68 @@
 //        [2][3]         [3]
 namespace Piece {
 
-    // Deliberate using max value of uint8_t to represent invalids
-    static inline constexpr uint8_t kNanInd = UINT8_MAX;
-
-    // Each piece consists of 4 cells; that's why it's also called tetromino
-    static inline constexpr uint8_t kNPiece = 4;
-
-    // static constexpr uint8_t NUM = 5;
-
-    // sparse representation of tetrominos on the board as indices
-    using Coord = std::array<uint8_t, kNPiece>;
-
-    enum class Type : uint8_t {
-        I = 0,
-        L,
-        T,
-        Z,
-        O,
-    };
-
-    enum class Shape : uint8_t {
-        I0 = 0,
-        I1,
-        L0,
-        L1,
-        L2,
-        L3,
-        T0,
-        T1,
-        T2,
-        T3,
-        Z0,
-        Z1,
-        O0,
-    };
-
-    static inline const Type rand_type() {
-        return static_cast<Type>(rand() % 5);
-    }
-
-    static inline constexpr Shape next_shape(const Shape &cur) {
-        switch (cur) {
-        case Shape::I1:
-            return Shape::I0;
-        case Shape::L3:
-            return Shape::L0;
-        case Shape::T3:
-            return Shape::T0;
-        case Shape::Z1:
-            return Shape::Z0;
-        case Shape::O0:
-            return Shape::O0;
-        default:
-            return static_cast<Shape>(static_cast<uint8_t>(cur) + 1);
-        }
-    }
-
-    // Piece initial positions
-    namespace Init {
-
-        static constexpr Coord I = {3, 4, 5, 6};
-        static constexpr Coord L = {4, 14, 24, 25};
-        static constexpr Coord T = {4, 5, 6, 15};
-        static constexpr Coord Z = {4, 5, 15, 16};
-        static constexpr Coord O = {4, 5, 14, 15};
-
-    } // namespace Init
-
     namespace {
+        enum class Type : uint8_t {
+            I = 0,
+            L,
+            T,
+            Z,
+            O,
+        };
+
+        // Rotating Orientation
+        enum class State : uint8_t {
+            NONE = 0,
+            I0,
+            I1,
+            L0,
+            L1,
+            L2,
+            L3,
+            T0,
+            T1,
+            T2,
+            T3,
+            Z0,
+            Z1,
+            O0,
+        };
+
+        static constexpr uint8_t kNState = 14;
+
+        static constexpr std::array<uint8_t, kNState> kMapState2Next = {
+            static_cast<uint8_t>(State::NONE), static_cast<uint8_t>(State::I1),
+            static_cast<uint8_t>(State::I0),   static_cast<uint8_t>(State::L1),
+            static_cast<uint8_t>(State::L2),   static_cast<uint8_t>(State::L3),
+            static_cast<uint8_t>(State::L0),   static_cast<uint8_t>(State::T1),
+            static_cast<uint8_t>(State::T2),   static_cast<uint8_t>(State::T3),
+            static_cast<uint8_t>(State::T0),   static_cast<uint8_t>(State::Z1),
+            static_cast<uint8_t>(State::Z0),   static_cast<uint8_t>(State::O0),
+        };
+
+        static inline constexpr uint8_t next_state(const uint8_t state) {
+            try {
+                return kMapState2Next.at(state);
+            } catch (const std::out_of_range &e) {
+                return static_cast<uint8_t>(State::NONE);
+            }
+        }
+
+        // Initial states of the pieces
+        static constexpr std::array<std::pair<uint8_t, brick_t>, 5>
+            kMapBrickInit = {
+                std::make_pair(static_cast<uint8_t>(State::I0),
+                               brick_t{3, 4, 5, 6}),
+                std::make_pair(static_cast<uint8_t>(State::L0),
+                               brick_t{4, 14, 24, 25}),
+                std::make_pair(static_cast<uint8_t>(State::T0),
+                               brick_t{4, 5, 6, 15}),
+                std::make_pair(static_cast<uint8_t>(State::Z0),
+                               brick_t{4, 5, 15, 16}),
+                std::make_pair(static_cast<uint8_t>(State::O0),
+                               brick_t{4, 5, 14, 15}),
+        };
+
         // get row ID from index
         static inline constexpr uint8_t row(const uint8_t &idx) {
             return idx / WIDTH;
@@ -112,349 +105,338 @@ namespace Piece {
 
         // index of the cell which will be occupied when moving left
         static inline constexpr uint8_t l(const uint8_t &idx) {
-            if (col(idx) == 0 || idx == kNanInd) {
-                return kNanInd;
+            if (col(idx) == 0 || idx == IDX_NA) {
+                return IDX_NA;
             }
             return idx - 1;
         }
 
         // index of the cell which will be occupied when moving right
         static inline constexpr uint8_t r(const uint8_t &idx) {
-            if (col(idx) == WIDTH - 1 || idx == kNanInd) {
-                return kNanInd;
+            if (col(idx) == WIDTH - 1 || idx == IDX_NA) {
+                return IDX_NA;
             }
             return idx + 1;
         }
 
         // index of the cell which will be occupied when moving up
         static inline constexpr uint8_t u(const uint8_t &idx) {
-            if (row(idx) == 0 || idx == kNanInd) {
-                return kNanInd;
+            if (row(idx) == 0 || idx == IDX_NA) {
+                return IDX_NA;
             }
             return idx - WIDTH;
         }
 
         // index of the cell which will be occupied when moving down
         static inline constexpr uint8_t d(const uint8_t &idx) {
-            if (row(idx) == HEIGHT - 1 || idx == kNanInd) {
-                return kNanInd;
+            if (row(idx) == HEIGHT - 1 || idx == IDX_NA) {
+                return IDX_NA;
             }
             return idx + WIDTH;
         }
 
+        static const std::array<brick_t (*)(const brick_t &), kNState>
+            kMapState2FnRotate = {
+                // NONE: trivial
+                [](const brick_t &src) { return src; },
+                // I0: -> I1
+                //
+                // [ ][ ]          [ ][0]
+                // [0][1][2][3] -> [ ][1][ ][ ]
+                //    [ ][ ][ ]       [2][ ][ ]
+                //    [ ][ ][ ]       [3][ ][ ]
+                [](const brick_t &src) {
+                    return brick_t{u(src[1]), src[1], d(src[1]), d(d(src[1]))};
+                },
+                // I1: -> I0
+                //
+                // [ ][0]          [ ][ ]
+                // [ ][1][ ][ ] -> [0][1][2][3]
+                //    [2][ ][ ]       [ ][ ][ ]
+                //    [3][ ][ ]       [ ][ ][ ]
+                [](const brick_t &src) {
+                    return brick_t{l(src[1]), src[1], r(src[1]), r(r(src[1]))};
+                },
+                // L0: -> L1
+                //
+                // [ ][0][ ]    [ ][ ][0]
+                // [ ][1][ ] -> [1][2][3]
+                //    [2][3]       [ ][ ]
+                [](const brick_t &src) {
+                    return brick_t{r(src[0]), l(src[1]), src[1], r(src[1])};
+                },
+                // L1: -> L2
+                //
+                // [ ][ ][0]    [0][1][ ]
+                // [1][2][3] -> [ ][2][ ]
+                // [ ][ ]       [ ][3]
+                [](const brick_t &src) {
+                    return brick_t{u(src[1]), l(src[0]), src[2], d(src[2])};
+                },
+                // L2: -> L3
+                //
+                // [0][1]       [ ][ ]
+                // [ ][2][ ] -> [0][1][2]
+                // [ ][3][ ]    [3][ ][ ]
+                [](const brick_t &src) {
+                    return brick_t{l(src[2]), src[2], r(src[2]), l(src[3])};
+                },
+                // L3: -> L0
+                //
+                //    [ ][ ]       [0][ ]
+                // [0][1][2] -> [ ][1][ ]
+                // [3][ ][ ]    [ ][2][3]
+                [](const brick_t &src) {
+                    return brick_t{u(src[1]), src[1], r(src[3]), d(src[2])};
+                },
+                // T0: -> T1
+                //
+                //    [ ][ ]       [0][ ]
+                // [0][1][2] -> [ ][1][2]
+                // [ ][3][ ]    [ ][3][ ]
+                [](const brick_t &src) {
+                    return brick_t{u(src[1]), src[1], src[2], src[3]};
+                },
+                // T1: -> T2
+                //
+                // [ ][0][ ]    [ ][0][ ]
+                // [ ][1][2] -> [1][2][3]
+                //    [3][ ]       [ ][ ]
+                [](const brick_t &src) {
+                    return brick_t{src[0], l(src[1]), src[1], src[2]};
+                },
+                // T2: -> T3
+                //
+                // [ ][0][ ]    [ ][0][ ]
+                // [1][2][3] -> [1][2][ ]
+                // [ ][ ]       [ ][3]
+                [](const brick_t &src) {
+                    return brick_t{src[0], src[1], src[2], d(src[2])};
+                },
+                // T3: -> T0
+                //
+                // [ ][0]       [ ][ ]
+                // [1][2][ ] -> [0][1][2]
+                // [ ][3][ ]    [ ][3][ ]
+                [](const brick_t &src) {
+                    return brick_t{src[1], src[2], r(src[2]), src[3]};
+                },
+                // Z0: -> Z1
+                //
+                //       [ ]          [0]
+                // [0][1][ ] -> [ ][1][2]
+                // [ ][2][3]    [ ][3][ ]
+                [](const brick_t &src) {
+                    return brick_t{u(r(src[1])), src[1], r(src[1]), src[2]};
+                },
+                // Z1: -> Z0
+                //
+                //       [0][ ]          [ ][ ]
+                // [ ][1][2][ ] -> [0][1][ ][ ]
+                // [ ][3][ ]       [ ][2][3]
+                [](const brick_t &src) {
+                    return brick_t{l(src[1]), src[1], src[3], r(src[3])};
+                },
+                // O0: -> O0 (trivial)
+                [](const brick_t &src) { return src; },
+        };
+
+        // NOTE: FSM
+        // update rotate coord based on current position and orientation,
+        // pieces should always follow the top-down, left-right order
+        static inline void update_rot(const brick_t &src, const uint8_t state,
+                                      brick_t &dst) {
+            try {
+                dst = kMapState2FnRotate.at(state)(src);
+            } catch (const std::out_of_range &e) {
+                dst = src;
+            }
+        }
+
+        // TODO: currently use placeholder (`src[0]`) when no more than 5 cells
+        // are occupied
+        static const std::array<brick_t (*)(const brick_t &), kNState>
+            kMapState2FnAround = {
+                // NONE: trivial
+                [](const brick_t &src) { return src; },
+                // I0: -> I1
+                //
+                // [ ]             [ ][0]
+                // [0][1][2][3] ->    [1]
+                //       [ ][ ]       [2][ ][ ]
+                //       [ ]          [3][ ]
+                [](const brick_t &src) {
+                    return brick_t{u(src[0]), d(src[2]), d(src[3]),
+                                   d(d(src[2]))};
+                },
+                // I1: -> I0
+                //
+                // [ ][0]          [ ]
+                //    [1]       -> [0][1][2][3]
+                //    [2][ ][ ]          [ ][ ]
+                //    [3][ ]             [ ]
+                [](const brick_t &src) {
+                    return brick_t{l(src[0]), r(src[2]), r(r(src[2])),
+                                   r(src[3])};
+                },
+                // L0: -> L1
+                //
+                // [ ][0]       [ ]   [0]
+                //    [1]    -> [1][2][3]
+                //    [2][3]
+                [](const brick_t &src) {
+                    return brick_t{l(src[0]), src[0], src[0], src[0]};
+                },
+                // L1: -> L2
+                //
+                //       [0]    [0][1]
+                // [0][1][3] ->    [2]
+                // [ ]          [ ][3]
+                [](const brick_t &src) {
+                    return brick_t{d(src[0]), src[0], src[0], src[0]};
+                },
+                // L2: -> L3
+                //
+                // [0][1]
+                //    [2]    -> [X][X][X]
+                //    [3][ ]    [X]   [ ]
+                [](const brick_t &src) {
+                    return brick_t{r(src[3]), src[0], src[0], src[0]};
+                },
+                // L3: -> L0
+                //
+                //       [ ]    [X][ ]
+                // [0][1][2] -> [X]
+                // [3]          [X][X]
+                [](const brick_t &src) {
+                    return brick_t{u(src[2]), src[0], src[0], src[0]};
+                },
+                // T0: -> T1
+                //
+                //       [ ]       [X][ ]
+                // [0][1][2] ->    [X][X]
+                // [ ][3][ ]    [ ][X][ ]
+                [](const brick_t &src) {
+                    return brick_t{u(src[2]), d(src[0]), d(src[2]), src[0]};
+                },
+                // T1: -> T2
+                //
+                // [ ][0][ ]    [ ][X][ ]
+                //    [1][2] -> [X][X][X]
+                //    [3][ ]          [ ]
+                [](const brick_t &src) {
+                    return brick_t{l(src[0]), r(src[0]), r(src[3]), src[0]};
+                },
+                // T2: -> T3
+                //
+                // [ ][0][ ]    [ ][X][ ]
+                // [1][2][3] -> [X][X]
+                // [ ]          [ ][X]
+                [](const brick_t &src) {
+                    return brick_t{l(src[0]), r(src[0]), d(src[1]), src[0]};
+                },
+                // T3: -> T0
+                //
+                // [ ][0]       [ ]
+                // [1][2]    -> [X][X][X]
+                // [ ][3][ ]    [ ][X][ ]
+                [](const brick_t &src) {
+                    return brick_t{l(src[0]), l(src[3]), r(src[3]), src[0]};
+                },
+                // Z0: -> Z1
+                //
+                //                    [X]
+                // [0][1]    ->    [X][X]
+                // [ ][2][3]    [ ][X]
+                [](const brick_t &src) {
+                    return brick_t{d(src[0]), src[0], src[0], src[0]};
+                },
+                // Z1: -> Z0
+                //
+                //    [3][ ]          [ ]
+                // [1][2][ ] -> [X][X][ ]
+                // [0]             [X][X]
+                [](const brick_t &src) {
+                    return brick_t{r(src[3]), r(src[2]), src[0], src[0]};
+                },
+                // O0: -> O0 (trivial)
+                [](const brick_t &src) { return src; },
+        };
+
+        // NOTE: FSM
+        // update indices of cells around the piece which may prevent rotation
+        // (rotated cells are not included)
+        static inline void update_ard(const brick_t &src, const uint8_t shape,
+                                      brick_t &dst) {
+            try {
+                dst = kMapState2FnAround.at(shape)(src);
+            } catch (const std::out_of_range &e) {
+                dst = src;
+            }
+        }
+
+        // update left coord
+        static inline void update_left(const brick_t &src, brick_t &dst) {
+            for (uint8_t i = 0; i < NBRK; ++i) {
+                dst[i] = l(src[i]);
+            }
+        }
+
+        // update right coord
+        static inline void update_right(const brick_t &src, brick_t &dst) {
+            for (uint8_t i = 0; i < NBRK; ++i) {
+                dst[i] = r(src[i]);
+            }
+        }
+
+        // update down coord
+        static inline void update_down(const brick_t &src, brick_t &dst) {
+            for (uint8_t i = 0; i < NBRK; ++i) {
+                dst[i] = d(src[i]);
+            }
+        }
+
     } // namespace
-
-    // update rotate coord based on current position and shape
-    // pieces should always follow the top-down, left-right order
-    static inline void update_rot(const Coord &src, const Piece::Shape &shape,
-                                  Coord &dst) {
-        switch (shape) {
-        // from I0 to I1
-        //
-        // [ ][ ]          [ ][0]
-        // [0][1][2][3] -> [ ][1][ ][ ]
-        //    [ ][ ][ ]       [2][ ][ ]
-        //    [ ][ ][ ]       [3][ ][ ]
-        case Piece::Shape::I0:
-            dst = {u(src[1]), src[1], d(src[1]), d(d(src[1]))};
-            break;
-        // from I1 to I0
-        //
-        // [ ][0]          [ ][ ]
-        // [ ][1][ ][ ] -> [0][1][2][3]
-        //    [2][ ][ ]       [ ][ ][ ]
-        //    [3][ ][ ]       [ ][ ][ ]
-        case Piece::Shape::I1:
-            dst = {l(src[1]), src[1], r(src[1]), r(r(src[1]))};
-            break;
-        // from L0 to L1
-        //
-        // [ ][0][ ]    [ ][ ][0]
-        // [ ][1][ ] -> [1][2][3]
-        //    [2][3]       [ ][ ]
-        case Piece::Shape::L0:
-            dst = {r(src[0]), l(src[1]), src[1], r(src[1])};
-            break;
-        // from L1 to L2
-        //
-        // [ ][ ][0]    [0][1][ ]
-        // [1][2][3] -> [ ][2][ ]
-        // [ ][ ]       [ ][3]
-        case Piece::Shape::L1:
-            dst = {u(src[1]), l(src[0]), src[2], d(src[2])};
-            break;
-        // from L2 to L3
-        //
-        // [0][1]       [ ][ ]
-        // [ ][2][ ] -> [0][1][2]
-        // [ ][3][ ]    [3][ ][ ]
-        case Piece::Shape::L2:
-            dst = {l(src[2]), src[2], r(src[2]), l(src[3])};
-            break;
-        // from L3 to L0
-        //
-        //    [ ][ ]       [0][ ]
-        // [0][1][2] -> [ ][1][ ]
-        // [3][ ][ ]    [ ][2][3]
-        case Piece::Shape::L3:
-            dst = {u(src[1]), src[1], r(src[3]), d(src[2])};
-            break;
-        // from T0 to T1
-        //
-        //    [ ][ ]       [0][ ]
-        // [0][1][2] -> [ ][1][2]
-        // [ ][3][ ]    [ ][3][ ]
-        case Piece::Shape::T0:
-            dst = {u(src[1]), src[1], src[2], src[3]};
-            break;
-        // from T1 to T2
-        //
-        // [ ][0][ ]    [ ][0][ ]
-        // [ ][1][2] -> [1][2][3]
-        //    [3][ ]       [ ][ ]
-        case Piece::Shape::T1:
-            dst = {src[0], l(src[1]), src[1], src[2]};
-            break;
-        // from T2 to T3
-        //
-        // [ ][0][ ]    [ ][0][ ]
-        // [1][2][3] -> [1][2][ ]
-        // [ ][ ]       [ ][3]
-        case Piece::Shape::T2:
-            dst = {src[0], src[1], src[2], d(src[2])};
-            break;
-        // from T3 to T0
-        //
-        // [ ][0]       [ ][ ]
-        // [1][2][ ] -> [0][1][2]
-        // [ ][3][ ]    [ ][3][ ]
-        case Piece::Shape::T3:
-            dst = {src[1], src[2], r(src[2]), src[3]};
-            break;
-        // from Z0 to Z1
-        //
-        //       [ ]          [0]
-        // [0][1][ ] -> [ ][1][2]
-        // [ ][2][3]    [ ][3][ ]
-        case Piece::Shape::Z0:
-            dst = {u(r(src[1])), src[1], r(src[1]), src[2]};
-            break;
-        // from Z1 to Z0
-        //
-        //       [0][ ]          [ ][ ]
-        // [ ][1][2][ ] -> [0][1][ ][ ]
-        // [ ][3][ ]       [ ][2][3]
-        case Piece::Shape::Z1:
-            dst = {l(src[1]), src[1], src[3], r(src[3])};
-            break;
-        default:
-            dst = src;
-            break;
-        }
-    }
-
-    // update indices of cells around the piece which may prevent rotation
-    // (rotated cells are not included)
-    //
-    // TODO: currently use placeholder when no more than 5 cells are
-    //       occupied
-    static inline void update_ard(const Coord &src, const Piece::Shape &shape,
-                                  Coord &dst) {
-        uint8_t plh = src[0]; // placeholder
-        switch (shape) {
-        // from I0 to I1
-        //
-        // [ ]             [ ][0]
-        // [0][1][2][3] ->    [1]
-        //       [ ][ ]       [2][ ][ ]
-        //       [ ]          [3][ ]
-        case Piece::Shape::I0:
-            dst = {u(src[0]), d(src[2]), d(src[3]), d(d(src[2]))};
-            break;
-
-        // from I1 to I0
-        //
-        // [ ][0]          [ ]
-        //    [1]       -> [0][1][2][3]
-        //    [2][ ][ ]          [ ][ ]
-        //    [3][ ]             [ ]
-        case Piece::Shape::I1:
-            dst = {l(src[0]), r(src[2]), r(r(src[2])), r(src[3])};
-            break;
-
-        // from L0 to L1
-        //
-        // [ ][0]       [ ]   [0]
-        //    [1]    -> [1][2][3]
-        //    [2][3]
-        case Piece::Shape::L0:
-            dst = {l(src[0]), plh, plh, plh};
-            break;
-
-        // from L1 to L2
-        //
-        //       [0]    [0][1]
-        // [0][1][3] ->    [2]
-        // [ ]          [ ][3]
-        case Piece::Shape::L1:
-            dst = {d(src[0]), plh, plh, plh};
-            break;
-
-        // from L2 to L3
-        //
-        // [0][1]
-        //    [2]    -> [X][X][X]
-        //    [3][ ]    [X]   [ ]
-        case Piece::Shape::L2:
-            dst = {r(src[3]), plh, plh, plh};
-            break;
-
-        // from L3 to L0
-        //
-        //       [ ]    [X][ ]
-        // [0][1][2] -> [X]
-        // [3]          [X][X]
-        case Piece::Shape::L3:
-            dst = {u(src[2]), plh, plh, plh};
-            break;
-
-        // from T0 to T1
-        //
-        //       [ ]       [X][ ]
-        // [0][1][2] ->    [X][X]
-        // [ ][3][ ]    [ ][X][ ]
-        case Piece::Shape::T0:
-            dst = {u(src[2]), d(src[0]), d(src[2]), plh};
-            break;
-
-        // from T1 to T2
-        //
-        // [ ][0][ ]    [ ][X][ ]
-        //    [1][2] -> [X][X][X]
-        //    [3][ ]          [ ]
-        case Piece::Shape::T1:
-            dst = {l(src[0]), r(src[0]), r(src[3]), plh};
-            break;
-
-        // from T2 to T3
-        //
-        // [ ][0][ ]    [ ][X][ ]
-        // [1][2][3] -> [X][X]
-        // [ ]          [ ][X]
-        case Piece::Shape::T2:
-            dst = {l(src[0]), r(src[0]), d(src[1]), plh};
-            break;
-
-        // from T3 to T0
-        //
-        // [ ][0]       [ ]
-        // [1][2]    -> [X][X][X]
-        // [ ][3][ ]    [ ][X][ ]
-        case Piece::Shape::T3:
-            dst = {l(src[0]), l(src[3]), r(src[3]), plh};
-            break;
-
-        // from Z0 to Z1
-        //
-        //                    [X]
-        // [0][1]    ->    [X][X]
-        // [ ][2][3]    [ ][X]
-        case Piece::Shape::Z0:
-            dst = {d(src[0]), plh, plh, plh};
-            break;
-
-        // from Z1 to Z0
-        //
-        //    [3][ ]          [ ]
-        // [1][2][ ] -> [X][X][ ]
-        // [0]             [X][X]
-        case Piece::Shape::Z1:
-            dst = {r(src[3]), r(src[2]), plh, plh};
-            break;
-
-        default:
-            dst = {plh, plh, plh, plh};
-            break;
-        }
-    }
-
-    // update left coord
-    static inline void update_left(const Coord &src, Coord &dst) {
-        for (uint8_t i = 0; i < kNPiece; ++i) {
-            dst[i] = l(src[i]);
-        }
-    }
-
-    // update right coord
-    static inline void update_right(const Coord &src, Coord &dst) {
-        for (uint8_t i = 0; i < kNPiece; ++i) {
-            dst[i] = r(src[i]);
-        }
-    }
-
-    // update down coord
-    static inline void update_down(const Coord &src, Coord &dst) {
-        for (uint8_t i = 0; i < kNPiece; ++i) {
-            dst[i] = d(src[i]);
-        }
-    }
 
     // holds the current piece type and position
     struct Context {
-        Shape shape;  // piece current shape
-        Coord cur;    // current position
-        Coord left;   // left position
-        Coord right;  // right position
-        Coord down;   // down position
-        Coord rotate; // rotated position
-        Coord round;  // surrounding position (detect rotation collision)
+        uint8_t state;  // piece current shape
+        brick_t cur;    // current position
+        brick_t left;   // left position
+        brick_t right;  // right position
+        brick_t down;   // down position
+        brick_t rotate; // rotated position
+        brick_t round;  // surrounding position (detect rotation collision)
 
         // initialize piece context according to index
-        inline void Spawn(const Type &index) {
-            switch (index) {
-            case Type::I:
-                shape = Shape::I0;
-                cur = Init::I;
-                break;
-            case Type::L:
-                shape = Shape::L0;
-                cur = Init::L;
-                break;
-            case Type::T:
-                shape = Shape::T0;
-                cur = Init::T;
-                break;
-            case Type::Z:
-                shape = Shape::Z0;
-                cur = Init::Z;
-                break;
-            default:
-                shape = Shape::O0;
-                cur = Init::O;
-                break;
+        inline void Spawn(const uint8_t &index) {
+            try {
+                std::tie(state, cur) = kMapBrickInit.at(index);
+            } catch (const std::out_of_range &e) {
+                std::tie(state, cur) = kMapBrickInit.at(0);
             }
 
             update_left(cur, left);
             update_right(cur, right);
             update_down(cur, down);
-            update_rot(cur, shape, rotate);
-            update_ard(cur, shape, round);
+            update_rot(cur, state, rotate);
+            update_ard(cur, state, round);
         }
 
         inline void Rotate() {
             // replace current with rotate
             cur = rotate;
             // update shape
-            shape = next_shape(shape);
+            state = next_state(state);
 
             // rotate go rotate
-            update_rot(cur, shape, rotate);
+            update_rot(cur, state, rotate);
 
             // update left, right, down and around
             update_left(cur, left);
             update_right(cur, right);
             update_down(cur, down);
-            update_ard(cur, shape, round);
+            update_ard(cur, state, round);
         }
 
         inline void Left() {
@@ -466,8 +448,8 @@ namespace Piece {
             update_left(cur, left);
             // update down, rotate and around
             update_down(cur, down);
-            update_rot(cur, shape, rotate);
-            update_ard(cur, shape, round);
+            update_rot(cur, state, rotate);
+            update_ard(cur, state, round);
         }
 
         inline void Right() {
@@ -479,8 +461,8 @@ namespace Piece {
             update_right(cur, right);
             // update down, rotate and around
             update_down(cur, down);
-            update_rot(cur, shape, rotate);
-            update_ard(cur, shape, round);
+            update_rot(cur, state, rotate);
+            update_ard(cur, state, round);
         }
 
         inline void Down() {
@@ -491,8 +473,8 @@ namespace Piece {
             // update left, right, rotate and around
             update_left(cur, left);
             update_right(cur, right);
-            update_rot(cur, shape, rotate);
-            update_ard(cur, shape, round);
+            update_rot(cur, state, rotate);
+            update_ard(cur, state, round);
         }
     };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,16 +5,16 @@
 
 // collision / out of bound detection
 // return false if it is a valid piece placement
-static inline bool collide(const Piece::Coord &coord, const Board::Matrix &mx) {
+static inline bool collide(const brick_t &indices, const field_t &mx) {
     // out of bound
-    for (const auto &i : coord) {
-        if (i == Piece::kNanInd) {
+    for (const auto &i : indices) {
+        if (i == IDX_NA) {
             return true;
         }
     }
     // collision detection
-    for (const auto &i : coord) {
-        if (mx[i] != Board::Pixel::NUL) {
+    for (const auto &i : indices) {
+        if (mx[i] != static_cast<uint8_t>(Board::Pixel::NUL)) {
             return true;
         }
     }
@@ -22,7 +22,7 @@ static inline bool collide(const Piece::Coord &coord, const Board::Matrix &mx) {
 }
 
 // visualize the board matrix
-static inline void to_str(const Board::Matrix &mx, Term::Screen &out) {
+static inline void to_str(const field_t &mx, Term::Screen &out) {
     for (uint8_t row = 0; row < HEIGHT; ++row) {
         std::string line = "";
         for (uint8_t col = 0; col < WIDTH; ++col) {
@@ -98,7 +98,7 @@ int main() {
         }
 
         // fill the board with blocks
-        board.UpdateBoard(piece);
+        board.UpdateBoard(piece.cur);
         to_str(board.active, screen);
 
         // clear the screen


### PR DESCRIPTION
- Rename project to TermTetris
- Unify board and piece representations using `uint8_t` and new typedefs:
  - `brick_t`: sparse 4-cell tetromino representation
  - `field_t`: dense full board representation
- Remove `board` dependency on `piece` logic
- Migrate to FSM-style state handling
- Simplify `Piece` and rotation logic using lookup tables
- Switched to lld linker, enforced C++20 in CMake
- Added debug/release presets, updated build.sh accordingly
